### PR TITLE
No need to set `PackageId` since the project rename

### DIFF
--- a/src/Falu/Falu.csproj
+++ b/src/Falu/Falu.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>netstandard2.1;net7.0;net8.0</TargetFrameworks>
     <Description>The official client library for Falu. (https://falu.io)</Description>
     <PackageIcon>falu-logo.png</PackageIcon>
-    <PackageId>Falu</PackageId>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
In #244, projects were renamed so no longer need to set `PackageId` in the project file.