### PR TITLE
Set `AssemblyName` to `FaluSdk` and `PackageId` to `Falu`

### DIFF
--- a/falu-dotnet.sln
+++ b/falu-dotnet.sln
@@ -3,16 +3,16 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31919.166
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Falu", "src\Falu\Falu.csproj", "{963DEBFA-CB4D-4A2F-8AE4-5C64D6917730}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Falu.Tests", "tests\Falu.Tests\Falu.Tests.csproj", "{BC55832D-F48D-41CC-80A5-B4C36C289C3F}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{C024C82C-F934-46C4-A477-09B3890B6127}"
 	ProjectSection(SolutionItems) = preProject
 		src\Directory.Build.props = src\Directory.Build.props
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Falu", "src\Falu\Falu.csproj", "{963DEBFA-CB4D-4A2F-8AE4-5C64D6917730}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{F29660E1-F3A8-4EB9-A189-B26053912E98}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Falu.Tests", "tests\Falu.Tests\Falu.Tests.csproj", "{BC55832D-F48D-41CC-80A5-B4C36C289C3F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Falu/Falu.csproj
+++ b/src/Falu/Falu.csproj
@@ -6,6 +6,16 @@
     <PackageIcon>falu-logo.png</PackageIcon>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!--
+      The project is named Falu but produces and assembly named FaluSdk and not Falu because it is used
+      in the CLI which produces an assembly/executable also named Falu hence causes collisions and build failure.
+      Instead of renaming the whole project, we set the AssemblyName and PackageId to what we want.
+    -->
+    <AssemblyName>FaluSdk</AssemblyName>
+    <PackageId>Falu</PackageId>
+  </PropertyGroup>
+
   <ItemGroup>
     <InternalsVisibleTo Include="Falu.Tests" />
   </ItemGroup>


### PR DESCRIPTION
`falu-cli` generates an assembly/executable named `falu` hence why the output for this project should be `FaluSdk`. Before #244, this was the output.